### PR TITLE
Added includePaths

### DIFF
--- a/evil-icons.js
+++ b/evil-icons.js
@@ -1,7 +1,13 @@
 var fs = require('fs');
 var spritePath = __dirname + "/app/views/evil_icons/_icons.html";
 
+var includePaths = function () {
+  return [ __dirname + '/app/assets/stylesheets' ];
+};
+
 module.exports = {
+
+  includePaths: includePaths(),
 
   sprite: fs.readFileSync(spritePath).toString(),
 


### PR DESCRIPTION
Nice way to provide evil-icons include paths to sass compiler. So we can do

``` js
gulp
  .src(...)
  .pipe(sass({
    includePaths: require('evil-icons').includePaths
  });
```

and then

``` scss
@import 'evil-icons.css';
```
