### PR TITLE
Zero width and height for SVG

### DIFF
--- a/assets/evil-icons.js
+++ b/assets/evil-icons.js
@@ -19,7 +19,7 @@
     var klass   = "icon icon--" + name + " " + size + " " + (options.class || "");
 
 
-    var icon =  "<svg class='icon__cnt'>" +
+    var icon =  "<svg class='icon__cnt' width='0' height='0'>" +
                   "<use xlink:href='#" + name + "-icon' />" +
                 "</svg>";
 

--- a/lib/templates/evil-icons.js.erb
+++ b/lib/templates/evil-icons.js.erb
@@ -19,7 +19,7 @@
     var klass   = "icon icon--" + name + " " + size + " " + (options.class || "");
 
 
-    var icon =  "<svg class='icon__cnt'>" +
+    var icon =  "<svg class='icon__cnt' width='0' height='0'>" +
                   "<use xlink:href='#" + name + "-icon' />" +
                 "</svg>";
 


### PR DESCRIPTION
To avoid large icons while the page loads. Sizes are specified in the styles (width: 100%; height: 100%;)