### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Use the [Gulp plugin].
 Just include the assets into your page from CDN:
 
 ```html
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/evil-icons/1.9.0/evil-icons.min.css">
-<script src="https://cdn.jsdelivr.net/evil-icons/1.9.0/evil-icons.min.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/evil-icons@1.9.0/assets/evil-icons.min.css">
+<script src="https://cdn.jsdelivr.net/npm/evil-icons@1.9.0/assets/evil-icons.min.js"></script>
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.9.0",
   "description": "Evil Icons is a set of SVG icons designed extensively for using in modern web projects",
   "main": "evil-icons.js",
+  "jsdelivr": "assets/evil-icons.min.js"
   "scripts": {
     "test": "./node_modules/.bin/jscs evil-icons.js test && ./node_modules/.bin/mocha"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.9.0",
   "description": "Evil Icons is a set of SVG icons designed extensively for using in modern web projects",
   "main": "evil-icons.js",
-  "jsdelivr": "assets/evil-icons.min.js"
+  "jsdelivr": "assets/evil-icons.min.js",
   "scripts": {
     "test": "./node_modules/.bin/jscs evil-icons.js test && ./node_modules/.bin/mocha"
   },


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/evil-icons.

Feel free to ping me if you have any questions regarding this change.