### PR TITLE
make icon its own module

### DIFF
--- a/evil-icons.js
+++ b/evil-icons.js
@@ -1,31 +1,7 @@
 var fs          = require('fs');
 var spritePath  = __dirname + '/assets/sprite.svg';
 var sprite      = fs.readFileSync(spritePath).toString();
-
-function icon(name, options) {
-  var options = options || {};
-  var size    = options.size ? ' icon--' + options.size : '';
-  var classes = 'icon icon--' + name + size + ' ' + (options.class || '');
-  classes     = classes.trim();
-
-  var icon =  '<svg class="icon__cnt">' +
-                '<use xlink:href="#' + name + '-icon" />' +
-              '</svg>';
-
-  var html =  '<div class="' + classes + '">' +
-                wrapSpinner(icon, classes) +
-              '</div>';
-
-  return html;
-}
-
-function wrapSpinner(html, klass) {
-  if (klass.indexOf('spinner') > -1) {
-    return '<div class="icon__spinner">' + html + '</div>';
-  } else {
-    return html;
-  }
-}
+var icon        = require('./icon');;
 
 function buildParamsFromString(string) {
   var match, attr, value;

--- a/icon.js
+++ b/icon.js
@@ -1,0 +1,26 @@
+module.exports = icon;
+
+function icon(name, options) {
+  var options = options || {};
+  var size    = options.size ? ' icon--' + options.size : '';
+  var classes = 'icon icon--' + name + size + ' ' + (options.class || '');
+  classes     = classes.trim();
+
+  var icon =  '<svg class="icon__cnt">' +
+                '<use xlink:href="#' + name + '-icon" />' +
+              '</svg>';
+
+  var html =  '<div class="' + classes + '">' +
+                wrapSpinner(icon, classes) +
+              '</div>';
+
+  return html;
+}
+
+function wrapSpinner(html, klass) {
+  if (klass.indexOf('spinner') > -1) {
+    return '<div class="icon__spinner">' + html + '</div>';
+  } else {
+    return html;
+  }
+}


### PR DESCRIPTION
abstract the method to make icon markup into its own module.

this allows for it to be used in JavaScript environment that does not have access to nodeism like `fs` or `__dirname` (such as browserify or webpack).

this method could potentially be re-used in the browser asset bundle, as it is the same.

/cc @outpunk 